### PR TITLE
Add multithreading

### DIFF
--- a/conf/search_config.json
+++ b/conf/search_config.json
@@ -54,5 +54,6 @@
     },
     "pages": 4,
     "interval": 20,
-    "spelling": 2
+    "spelling": 2,
+    "multithreaded": true
 }


### PR DESCRIPTION
Added multithreaded support for the crawler. Setting can be configured using the `multithreaded=true` parameter in the search config